### PR TITLE
feat: add default feed subscriptions for new users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ All notable changes to NeuReed are documented in this file.
   - Enhanced support for media enclosures and feed metadata
 
 ### Added
+- **Default Feed Subscriptions for New Users**
+  - New users automatically subscribed to 9 curated feeds on signup
+  - Technology: TechCrunch, The Verge, Hacker News
+  - News: BBC News
+  - Science: Nature, Science Daily
+  - Positive News: Good News Network, Positive News
+  - Satire: The Onion
+  - Feeds and categories auto-created if missing
+  - Idempotent subscription process (safe to run multiple times)
+  - Users can unsubscribe from any feed after signup
+
+
 - **Nested Route Navigation with Browser History Support**
   - Implemented nested URL structure for feeds and articles (`/feeds/[feedId]`, `/feeds/[feedId]/articles/[articleId]`)
   - Browser back button now works granularly through feed changes and article navigation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,7 @@ Implementation: [src/lib/services/feed-settings-cascade.ts](src/lib/services/fee
 - Dynamic OAuth providers (Google, GitHub, Generic OAuth2)
 - JWT strategy with secure HTTP-only cookies
 - Custom callbacks add user ID to JWT token
+- Automatic default feed subscription on user creation
 
 **Authorization Pattern:**
 ```typescript
@@ -359,12 +360,30 @@ export const POST = createHandler(
 - Ensure same embedding provider used for query and articles
 - Verify HNSW index exists: `\d articles` in psql
 
+## Default Feeds for New Users
+
+New users are automatically subscribed to a curated set of 9 feeds covering:
+- **Technology**: TechCrunch, The Verge, Hacker News
+- **News**: BBC News
+- **Science**: Nature, Science Daily
+- **Positive News**: Good News Network, Positive News
+- **Satire**: The Onion
+
+**Implementation:**
+- Feeds created on-demand in [src/lib/services/default-feeds-service.ts](src/lib/services/default-feeds-service.ts)
+- Subscription happens in `createUser` event in auth.ts
+- Categories and feeds auto-created if missing
+- Idempotent (safe to run multiple times)
+
+See [docs/DEFAULT_FEEDS.md](docs/DEFAULT_FEEDS.md) for full documentation.
+
 ## Key Files to Reference
 
 - [src/lib/api-handler.ts](src/lib/api-handler.ts) - API route wrapper pattern
 - [src/lib/auth.ts](src/lib/auth.ts) - Authentication configuration
 - [src/lib/services/feed-refresh-service.ts](src/lib/services/feed-refresh-service.ts) - Core feed refresh logic
 - [src/lib/services/semantic-search-service.ts](src/lib/services/semantic-search-service.ts) - Vector search implementation
+- [src/lib/services/default-feeds-service.ts](src/lib/services/default-feeds-service.ts) - Default feed subscription
 - [src/lib/jobs/scheduler.ts](src/lib/jobs/scheduler.ts) - Cron job initialization
 - [prisma/schema.prisma](prisma/schema.prisma) - Database schema
 - [src/env.ts](src/env.ts) - Environment variable definitions

--- a/docs/DEFAULT_FEEDS.md
+++ b/docs/DEFAULT_FEEDS.md
@@ -1,0 +1,176 @@
+# Default Feeds for New Users
+
+## Overview
+
+NeuReed automatically subscribes new users to a curated set of default feeds when they create an account. This provides an immediate, high-quality reading experience without requiring users to manually search for and add feeds.
+
+## Default Feed List
+
+New users are automatically subscribed to the following feeds:
+
+### Technology
+- **TechCrunch** - `https://techcrunch.com/feed`
+- **The Verge** - `https://www.theverge.com/rss/index.xml`
+- **Hacker News** - `https://hnrss.org/frontpage`
+
+### News
+- **BBC News** - `https://feeds.bbci.co.uk/news/rss.xml`
+
+### Science
+- **Nature** - `https://www.nature.com/nature.rss`
+- **Science Daily** - `https://www.sciencedaily.com/rss/all.xml`
+
+### Positive News
+- **Good News Network** - `https://www.goodnewsnetwork.org/feed`
+- **Positive News** - `https://www.positive.news/feed`
+
+### Satire
+- **The Onion** - `https://www.theonion.com/rss`
+
+## How It Works
+
+### 1. User Creation Event
+When a new user signs up through any OAuth provider (Google, GitHub, or generic OAuth), the `createUser` event in NextAuth triggers the default feed subscription process.
+
+**Implementation:** `src/lib/auth.ts`
+
+```typescript
+events: {
+  async createUser({ user }) {
+    // ... create user preferences ...
+    
+    // Subscribe new user to default feeds
+    const { subscribeUserToDefaultFeeds } = await import(
+      "@/lib/services/default-feeds-service"
+    );
+    await subscribeUserToDefaultFeeds(user.id);
+  }
+}
+```
+
+### 2. Feed Initialization
+The system ensures all default feeds exist in the database before subscribing the user:
+
+1. Creates feed categories if they don't exist (Technology, News, Science, etc.)
+2. Creates feed entries with appropriate refresh intervals
+3. Associates feeds with their categories
+
+**Implementation:** `src/lib/services/default-feeds-service.ts`
+
+### 3. User Subscription
+The subscription process:
+- Checks if user is already subscribed (to handle account linking scenarios)
+- Creates `user_feeds` entries for each default feed
+- Skips feeds that the user is already subscribed to
+- Logs all operations for debugging
+
+## Configuration
+
+### Modifying Default Feeds
+
+To change the list of default feeds, edit the `DEFAULT_FEEDS` array in:
+
+```
+src/lib/services/default-feeds-service.ts
+```
+
+Each feed entry requires:
+```typescript
+{
+  name: "Feed Display Name",
+  url: "https://example.com/feed.xml",
+  categoryName: "Category Name"
+}
+```
+
+### Refresh Intervals
+
+Default refresh intervals are set in the seed file (`prisma/seed.ts`):
+- News feeds: 30 minutes (1800 seconds)
+- Technology feeds: 1 hour (3600 seconds)
+- Science/Journal feeds: 2 hours (7200 seconds)
+- Daily publications: 24 hours (86400 seconds)
+
+These can be adjusted per-feed or overridden by user preferences.
+
+## Database Seeding
+
+The database seed script (`prisma/seed.ts`) includes all default feeds, ensuring they're available immediately after setup:
+
+```bash
+npm run db:seed
+```
+
+This creates:
+- All default feed categories
+- All default feed entries
+- Feed-category associations
+- Sample articles for testing
+
+## Testing
+
+### Test New User Creation
+
+To verify the default feeds feature works:
+
+1. **Reset database (optional):**
+   ```bash
+   npm run db:reset
+   npm run db:seed
+   ```
+
+2. **Create a new user:**
+   - Sign up with a new account using any OAuth provider
+   - Or use the test user: `test@neureed.com`
+
+3. **Verify subscriptions:**
+   - Navigate to the feeds page
+   - Check that all 9 default feeds are subscribed
+   - Verify feeds are organized by category
+
+### Manual Testing Script
+
+You can also test the subscription logic directly:
+
+```typescript
+import { subscribeUserToDefaultFeeds } from "@/lib/services/default-feeds-service";
+
+// Subscribe a specific user to default feeds
+await subscribeUserToDefaultFeeds("user_id_here");
+```
+
+## Error Handling
+
+The subscription process is designed to be resilient:
+
+- **Feed creation failures:** Logged but don't block user creation
+- **Already subscribed:** Silently skipped, no duplicate subscriptions
+- **Missing feeds:** Warned and skipped
+- **Network issues:** Don't affect user authentication
+
+All errors are logged to the console for debugging.
+
+## Benefits
+
+1. **Immediate Value:** New users see content right away
+2. **Quality Content:** Curated, reliable sources across diverse topics
+3. **Balanced Perspective:** Mix of tech, news, science, and positive content
+4. **Easy Cleanup:** Users can unsubscribe from any feed they don't want
+
+## Future Enhancements
+
+Potential improvements to consider:
+
+1. **User Preferences:** Allow users to select interests during onboarding
+2. **Regional Feeds:** Add location-specific default feeds
+3. **Language Support:** Provide feeds in multiple languages
+4. **A/B Testing:** Test different default feed combinations
+5. **Admin Interface:** Manage default feeds through admin dashboard
+
+## Related Files
+
+- **Service:** `src/lib/services/default-feeds-service.ts`
+- **Auth Integration:** `src/lib/auth.ts`
+- **Database Seed:** `prisma/seed.ts`
+- **User Feed Service:** `src/lib/services/user-feed-service.ts`
+

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -17,6 +17,50 @@ async function main() {
     },
   });
 
+  const newsCategory = await prisma.categories.upsert({
+    where: { name: "News" },
+    update: {},
+    create: {
+      id: "cat_news_001",
+      name: "News",
+      description: "General news content",
+      updatedAt: new Date(),
+    },
+  });
+
+  const scienceCategory = await prisma.categories.upsert({
+    where: { name: "Science" },
+    update: {},
+    create: {
+      id: "cat_science_001",
+      name: "Science",
+      description: "Science and research content",
+      updatedAt: new Date(),
+    },
+  });
+
+  const positiveNewsCategory = await prisma.categories.upsert({
+    where: { name: "Positive News" },
+    update: {},
+    create: {
+      id: "cat_positive_001",
+      name: "Positive News",
+      description: "Uplifting and positive news stories",
+      updatedAt: new Date(),
+    },
+  });
+
+  const satireCategory = await prisma.categories.upsert({
+    where: { name: "Satire" },
+    update: {},
+    create: {
+      id: "cat_satire_001",
+      name: "Satire",
+      description: "Satirical news and comedy",
+      updatedAt: new Date(),
+    },
+  });
+
   const aiCategory = await prisma.categories.upsert({
     where: { name: "AI & Machine Learning" },
     update: {},
@@ -41,13 +85,41 @@ async function main() {
 
   console.log("✅ Categories created");
 
-  // Create sample feeds
+  // Create default feeds that all new users will be subscribed to
+  const techCrunchFeed = await prisma.feeds.upsert({
+    where: { url: "https://techcrunch.com/feed" },
+    update: {},
+    create: {
+      id: "feed_techcrunch_001",
+      name: "TechCrunch",
+      url: "https://techcrunch.com/feed",
+      settings: {
+        refreshInterval: 3600,
+      },
+      updatedAt: new Date(),
+    },
+  });
+
+  const vergeFeed = await prisma.feeds.upsert({
+    where: { url: "https://www.theverge.com/rss/index.xml" },
+    update: {},
+    create: {
+      id: "feed_verge_001",
+      name: "The Verge",
+      url: "https://www.theverge.com/rss/index.xml",
+      settings: {
+        refreshInterval: 3600,
+      },
+      updatedAt: new Date(),
+    },
+  });
+
   const hackerNewsFeed = await prisma.feeds.upsert({
     where: { url: "https://hnrss.org/frontpage" },
     update: {},
     create: {
       id: "feed_hn_001",
-      name: "Hacker News - Front Page",
+      name: "Hacker News",
       url: "https://hnrss.org/frontpage",
       settings: {
         refreshInterval: 3600,
@@ -56,6 +128,91 @@ async function main() {
     },
   });
 
+  const bbcNewsFeed = await prisma.feeds.upsert({
+    where: { url: "https://feeds.bbci.co.uk/news/rss.xml" },
+    update: {},
+    create: {
+      id: "feed_bbc_001",
+      name: "BBC News",
+      url: "https://feeds.bbci.co.uk/news/rss.xml",
+      settings: {
+        refreshInterval: 1800, // 30 minutes for news
+      },
+      updatedAt: new Date(),
+    },
+  });
+
+  const natureFeed = await prisma.feeds.upsert({
+    where: { url: "https://www.nature.com/nature.rss" },
+    update: {},
+    create: {
+      id: "feed_nature_001",
+      name: "Nature",
+      url: "https://www.nature.com/nature.rss",
+      settings: {
+        refreshInterval: 7200, // 2 hours for science journals
+      },
+      updatedAt: new Date(),
+    },
+  });
+
+  const scienceDailyFeed = await prisma.feeds.upsert({
+    where: { url: "https://www.sciencedaily.com/rss/all.xml" },
+    update: {},
+    create: {
+      id: "feed_sciencedaily_001",
+      name: "Science Daily",
+      url: "https://www.sciencedaily.com/rss/all.xml",
+      settings: {
+        refreshInterval: 7200,
+      },
+      updatedAt: new Date(),
+    },
+  });
+
+  const goodNewsNetworkFeed = await prisma.feeds.upsert({
+    where: { url: "https://www.goodnewsnetwork.org/feed" },
+    update: {},
+    create: {
+      id: "feed_goodnews_001",
+      name: "Good News Network",
+      url: "https://www.goodnewsnetwork.org/feed",
+      settings: {
+        refreshInterval: 7200,
+      },
+      updatedAt: new Date(),
+    },
+  });
+
+  const positiveNewsFeed = await prisma.feeds.upsert({
+    where: { url: "https://www.positive.news/feed" },
+    update: {},
+    create: {
+      id: "feed_positivenews_001",
+      name: "Positive News",
+      url: "https://www.positive.news/feed",
+      settings: {
+        refreshInterval: 7200,
+      },
+      updatedAt: new Date(),
+    },
+  });
+
+  const onionFeed = await prisma.feeds.upsert({
+    where: { url: "https://www.theonion.com/rss" },
+    update: {},
+    create: {
+      id: "feed_onion_001",
+      name: "The Onion",
+      url: "https://www.theonion.com/rss",
+      settings: {
+        refreshInterval: 3600,
+      },
+      updatedAt: new Date(),
+    },
+  });
+
+  // Additional sample feeds for variety
   const vercelBlogFeed = await prisma.feeds.upsert({
     where: { url: "https://vercel.com/blog/rss.xml" },
     update: {},
@@ -87,6 +244,35 @@ async function main() {
   console.log("✅ Feeds created");
 
   // Associate feeds with categories
+  // Technology feeds
+  await prisma.feed_categories.upsert({
+    where: {
+      feedId_categoryId: {
+        feedId: techCrunchFeed.id,
+        categoryId: techCategory.id,
+      },
+    },
+    update: {},
+    create: {
+      feedId: techCrunchFeed.id,
+      categoryId: techCategory.id,
+    },
+  });
+
+  await prisma.feed_categories.upsert({
+    where: {
+      feedId_categoryId: {
+        feedId: vergeFeed.id,
+        categoryId: techCategory.id,
+      },
+    },
+    update: {},
+    create: {
+      feedId: vergeFeed.id,
+      categoryId: techCategory.id,
+    },
+  });
+
   await prisma.feed_categories.upsert({
     where: {
       feedId_categoryId: {
@@ -101,6 +287,95 @@ async function main() {
     },
   });
 
+  // News feeds
+  await prisma.feed_categories.upsert({
+    where: {
+      feedId_categoryId: {
+        feedId: bbcNewsFeed.id,
+        categoryId: newsCategory.id,
+      },
+    },
+    update: {},
+    create: {
+      feedId: bbcNewsFeed.id,
+      categoryId: newsCategory.id,
+    },
+  });
+
+  // Science feeds
+  await prisma.feed_categories.upsert({
+    where: {
+      feedId_categoryId: {
+        feedId: natureFeed.id,
+        categoryId: scienceCategory.id,
+      },
+    },
+    update: {},
+    create: {
+      feedId: natureFeed.id,
+      categoryId: scienceCategory.id,
+    },
+  });
+
+  await prisma.feed_categories.upsert({
+    where: {
+      feedId_categoryId: {
+        feedId: scienceDailyFeed.id,
+        categoryId: scienceCategory.id,
+      },
+    },
+    update: {},
+    create: {
+      feedId: scienceDailyFeed.id,
+      categoryId: scienceCategory.id,
+    },
+  });
+
+  // Positive News feeds
+  await prisma.feed_categories.upsert({
+    where: {
+      feedId_categoryId: {
+        feedId: goodNewsNetworkFeed.id,
+        categoryId: positiveNewsCategory.id,
+      },
+    },
+    update: {},
+    create: {
+      feedId: goodNewsNetworkFeed.id,
+      categoryId: positiveNewsCategory.id,
+    },
+  });
+
+  await prisma.feed_categories.upsert({
+    where: {
+      feedId_categoryId: {
+        feedId: positiveNewsFeed.id,
+        categoryId: positiveNewsCategory.id,
+      },
+    },
+    update: {},
+    create: {
+      feedId: positiveNewsFeed.id,
+      categoryId: positiveNewsCategory.id,
+    },
+  });
+
+  // Satire feeds
+  await prisma.feed_categories.upsert({
+    where: {
+      feedId_categoryId: {
+        feedId: onionFeed.id,
+        categoryId: satireCategory.id,
+      },
+    },
+    update: {},
+    create: {
+      feedId: onionFeed.id,
+      categoryId: satireCategory.id,
+    },
+  });
+
+  // Additional feeds
   await prisma.feed_categories.upsert({
     where: {
       feedId_categoryId: {
@@ -136,28 +411,46 @@ async function main() {
     {
       id: "art_001",
       feedId: hackerNewsFeed.id,
-      title: "Sample Tech Article",
-      content: "This is a sample technology article for testing purposes.",
-      url: "https://example.com/tech-article-1",
+      title: "Sample Tech Article from Hacker News",
+      content: "This is a sample technology article for testing purposes from Hacker News.",
+      url: "https://example.com/tech-article-hn",
       publishedAt: new Date("2024-01-01"),
       updatedAt: new Date(),
     },
     {
       id: "art_002",
-      feedId: vercelBlogFeed.id,
-      title: "Next.js 15 Released",
-      content: "Sample content about Next.js 15 features and improvements.",
-      url: "https://example.com/nextjs-15",
+      feedId: techCrunchFeed.id,
+      title: "Startup Raises $50M in Series A",
+      content: "Sample content about a tech startup raising funding.",
+      url: "https://example.com/startup-funding",
       publishedAt: new Date("2024-01-02"),
       updatedAt: new Date(),
     },
     {
       id: "art_003",
-      feedId: openAIBlogFeed.id,
-      title: "Advances in AI Research",
-      content: "Sample content about recent advances in artificial intelligence.",
-      url: "https://example.com/ai-research",
+      feedId: bbcNewsFeed.id,
+      title: "Breaking News: Global Summit Announced",
+      content: "Sample content about international news.",
+      url: "https://example.com/global-summit",
       publishedAt: new Date("2024-01-03"),
+      updatedAt: new Date(),
+    },
+    {
+      id: "art_004",
+      feedId: natureFeed.id,
+      title: "New Discovery in Quantum Physics",
+      content: "Sample content about scientific breakthrough.",
+      url: "https://example.com/quantum-discovery",
+      publishedAt: new Date("2024-01-04"),
+      updatedAt: new Date(),
+    },
+    {
+      id: "art_005",
+      feedId: goodNewsNetworkFeed.id,
+      title: "Community Comes Together to Help Local Charity",
+      content: "Sample content about positive community action.",
+      url: "https://example.com/community-help",
+      publishedAt: new Date("2024-01-05"),
       updatedAt: new Date(),
     },
   ];

--- a/scripts/test-default-feeds.ts
+++ b/scripts/test-default-feeds.ts
@@ -1,0 +1,112 @@
+/**
+ * Test script to verify default feeds subscription
+ * 
+ * Usage:
+ *   npx tsx scripts/test-default-feeds.ts
+ */
+
+import { PrismaClient } from "@prisma/client";
+import { subscribeUserToDefaultFeeds, DEFAULT_FEEDS } from "../src/lib/services/default-feeds-service";
+
+const prisma = new PrismaClient();
+
+async function testDefaultFeeds() {
+  console.log("🧪 Testing Default Feeds Subscription\n");
+
+  try {
+    // Create a test user
+    const testUserId = `test_user_${Date.now()}`;
+    console.log(`Creating test user: ${testUserId}`);
+    
+    const testUser = await prisma.user.create({
+      data: {
+        id: testUserId,
+        email: `test_${Date.now()}@neureed.com`,
+        name: "Test User for Default Feeds",
+        emailVerified: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+
+    console.log(`✅ Test user created: ${testUser.email}\n`);
+
+    // Subscribe user to default feeds
+    console.log("Subscribing user to default feeds...\n");
+    await subscribeUserToDefaultFeeds(testUser.id);
+
+    // Verify subscriptions
+    console.log("\n📊 Verifying subscriptions...\n");
+    
+    const userFeeds = await prisma.user_feeds.findMany({
+      where: { userId: testUser.id },
+      include: {
+        feeds: true,
+      },
+    });
+
+    console.log(`✅ User is subscribed to ${userFeeds.length} feeds\n`);
+
+    // Check each default feed
+    console.log("Checking default feeds:\n");
+    for (const defaultFeed of DEFAULT_FEEDS) {
+      const subscription = userFeeds.find(
+        (uf) => uf.feeds.url === defaultFeed.url
+      );
+      
+      if (subscription) {
+        console.log(`✅ ${defaultFeed.name} - Subscribed`);
+      } else {
+        console.log(`❌ ${defaultFeed.name} - NOT subscribed`);
+      }
+    }
+
+    console.log("\n📋 Subscription details:\n");
+    userFeeds.forEach((uf) => {
+      console.log(`  - ${uf.feeds.name} (${uf.feeds.url})`);
+    });
+
+    // Test idempotency - try subscribing again
+    console.log("\n🔄 Testing idempotency (subscribing again)...\n");
+    await subscribeUserToDefaultFeeds(testUser.id);
+
+    const userFeedsAfter = await prisma.user_feeds.findMany({
+      where: { userId: testUser.id },
+    });
+
+    if (userFeedsAfter.length === userFeeds.length) {
+      console.log("✅ Idempotency test passed - no duplicate subscriptions");
+    } else {
+      console.log(
+        `❌ Idempotency test failed - expected ${userFeeds.length}, got ${userFeedsAfter.length}`
+      );
+    }
+
+    // Cleanup test user
+    console.log("\n🧹 Cleaning up test data...");
+    await prisma.user_feeds.deleteMany({
+      where: { userId: testUser.id },
+    });
+    await prisma.user.delete({
+      where: { id: testUser.id },
+    });
+    console.log("✅ Test data cleaned up");
+
+    console.log("\n🎉 All tests passed!\n");
+    
+  } catch (error) {
+    console.error("\n❌ Test failed:", error);
+    throw error;
+  }
+}
+
+testDefaultFeeds()
+  .then(async () => {
+    await prisma.$disconnect();
+    process.exit(0);
+  })
+  .catch(async (e) => {
+    console.error(e);
+    await prisma.$disconnect();
+    process.exit(1);
+  });
+

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -124,6 +124,15 @@ export const authConfig: NextAuthConfig = {
             },
           });
         }
+
+        // Subscribe new user to default feeds
+        const { subscribeUserToDefaultFeeds } = await import(
+          "@/lib/services/default-feeds-service"
+        );
+        await subscribeUserToDefaultFeeds(user.id).catch((error) => {
+          console.error("Failed to subscribe user to default feeds:", error);
+          // Don't fail user creation if feed subscription fails
+        });
       }
     },
   },

--- a/src/lib/services/default-feeds-service.ts
+++ b/src/lib/services/default-feeds-service.ts
@@ -1,0 +1,176 @@
+import { prisma } from "@/lib/db";
+import { subscribeFeed } from "./user-feed-service";
+
+/**
+ * Default feeds that new users will be subscribed to automatically
+ */
+export const DEFAULT_FEEDS = [
+  // Technology
+  {
+    name: "TechCrunch",
+    url: "https://techcrunch.com/feed",
+    categoryName: "Technology",
+  },
+  {
+    name: "The Verge",
+    url: "https://www.theverge.com/rss/index.xml",
+    categoryName: "Technology",
+  },
+  {
+    name: "Hacker News",
+    url: "https://hnrss.org/frontpage",
+    categoryName: "Technology",
+  },
+  // News
+  {
+    name: "BBC News",
+    url: "https://feeds.bbci.co.uk/news/rss.xml",
+    categoryName: "News",
+  },
+  // Science
+  {
+    name: "Nature",
+    url: "https://www.nature.com/nature.rss",
+    categoryName: "Science",
+  },
+  {
+    name: "Science Daily",
+    url: "https://www.sciencedaily.com/rss/all.xml",
+    categoryName: "Science",
+  },
+  // Positive News
+  {
+    name: "Good News Network",
+    url: "https://www.goodnewsnetwork.org/feed",
+    categoryName: "Positive News",
+  },
+  {
+    name: "Positive News",
+    url: "https://www.positive.news/feed",
+    categoryName: "Positive News",
+  },
+  // Satire
+  {
+    name: "The Onion",
+    url: "https://www.theonion.com/rss",
+    categoryName: "Satire",
+  },
+];
+
+/**
+ * Ensure all default feeds exist in the database
+ * Creates feeds if they don't exist, along with their categories
+ */
+export async function ensureDefaultFeedsExist(): Promise<void> {
+  console.log("🔄 Ensuring default feeds exist in database...");
+
+  for (const feedData of DEFAULT_FEEDS) {
+    try {
+      // Ensure category exists
+      const category = await prisma.categories.upsert({
+        where: { name: feedData.categoryName },
+        update: {},
+        create: {
+          id: `cat_${feedData.categoryName.toLowerCase().replace(/\s+/g, "_")}_${Date.now()}`,
+          name: feedData.categoryName,
+          description: `${feedData.categoryName} content`,
+          updatedAt: new Date(),
+        },
+      });
+
+      // Ensure feed exists
+      const feed = await prisma.feeds.upsert({
+        where: { url: feedData.url },
+        update: {
+          name: feedData.name, // Update name in case it changed
+        },
+        create: {
+          id: `feed_${feedData.name.toLowerCase().replace(/\s+/g, "_")}_${Date.now()}`,
+          name: feedData.name,
+          url: feedData.url,
+          settings: {
+            refreshInterval: 3600, // 1 hour default
+          },
+          updatedAt: new Date(),
+        },
+      });
+
+      // Ensure feed-category association exists
+      await prisma.feed_categories.upsert({
+        where: {
+          feedId_categoryId: {
+            feedId: feed.id,
+            categoryId: category.id,
+          },
+        },
+        update: {},
+        create: {
+          feedId: feed.id,
+          categoryId: category.id,
+        },
+      });
+
+      console.log(`✅ Ensured feed exists: ${feedData.name}`);
+    } catch (error) {
+      console.error(`❌ Failed to ensure feed exists: ${feedData.name}`, error);
+    }
+  }
+
+  console.log("✅ All default feeds ensured");
+}
+
+/**
+ * Subscribe a new user to all default feeds
+ * This should be called when a user is created
+ */
+export async function subscribeUserToDefaultFeeds(userId: string): Promise<void> {
+  console.log(`🔄 Subscribing user ${userId} to default feeds...`);
+
+  // First, ensure all default feeds exist in the database
+  await ensureDefaultFeedsExist();
+
+  let subscribedCount = 0;
+  let skippedCount = 0;
+
+  for (const feedData of DEFAULT_FEEDS) {
+    try {
+      // Find the feed by URL
+      const feed = await prisma.feeds.findUnique({
+        where: { url: feedData.url },
+      });
+
+      if (!feed) {
+        console.warn(`⚠️  Feed not found: ${feedData.name} (${feedData.url})`);
+        continue;
+      }
+
+      // Check if user is already subscribed
+      const existingSubscription = await prisma.user_feeds.findUnique({
+        where: {
+          userId_feedId: {
+            userId,
+            feedId: feed.id,
+          },
+        },
+      });
+
+      if (existingSubscription) {
+        console.log(`⏭️  User already subscribed to: ${feedData.name}`);
+        skippedCount++;
+        continue;
+      }
+
+      // Subscribe user to feed
+      await subscribeFeed(userId, feed.id, feedData.name);
+      subscribedCount++;
+      console.log(`✅ Subscribed to: ${feedData.name}`);
+    } catch (error) {
+      console.error(`❌ Failed to subscribe to feed: ${feedData.name}`, error);
+    }
+  }
+
+  console.log(
+    `✅ User subscription complete: ${subscribedCount} subscribed, ${skippedCount} skipped`
+  );
+}
+


### PR DESCRIPTION
This commit introduces a feature that automatically subscribes new users to a curated set of 9 feeds upon signup. The feeds cover various categories including Technology, News, Science, Positive News, and Satire. Additionally, the implementation ensures that feeds and categories are created on-demand if they do not exist, and the subscription process is idempotent, allowing it to be safely executed multiple times. Relevant updates are made to the CHANGELOG and the seeding script to reflect these changes.